### PR TITLE
Fix to be compatible with other extensions(e.g. Dynamic prompt)

### DIFF
--- a/scripts/ddetailer.py
+++ b/scripts/ddetailer.py
@@ -230,6 +230,12 @@ class DetectionDetailerScript(scripts.Script):
             masks_a = []
             masks_b_pre = []
 
+            init_prompts = init_image.info['parameters'].split('Negative prompt:')
+            init_pos_prompt = init_prompts[0].rstrip('\n')
+            init_neg_prompt = ''
+            if len(init_prompts) > 1:
+                init_neg_prompt = init_prompts[1].split('Steps:')[0].lstrip().rstrip('\n')
+            
             # Optional secondary pre-processing run
             if (dd_model_b != "None" and dd_preprocess_b): 
                 label_b_pre = "B"
@@ -253,7 +259,11 @@ class DetectionDetailerScript(scripts.Script):
                         p.image_mask = masks_b_pre[i]
                         if ( opts.dd_save_masks):
                             images.save_image(masks_b_pre[i], opts.outdir_ddetailer_masks, "", start_seed, p.prompt, opts.samples_format, p=p)
+                        p.prompt = init_pos_prompt
+                        p.negative_prompt = init_neg_prompt
                         processed = processing.process_images(p)
+                        p.prompt = p_txt.prompt
+                        p.negative_prompt = p_text.negative_prompt
                         p.seed = processed.seed + 1
                         p.init_images = processed.images
 
@@ -313,7 +323,11 @@ class DetectionDetailerScript(scripts.Script):
                         if ( opts.dd_save_masks):
                             images.save_image(masks_a[i], opts.outdir_ddetailer_masks, "", start_seed, p.prompt, opts.samples_format, p=p)
                         
+                        p.prompt = init_pos_prompt
+                        p.negative_prompt = init_neg_prompt
                         processed = processing.process_images(p)
+                        p.prompt = p_txt.prompt
+                        p.negative_prompt = p_text.negative_prompt
                         if initial_info is None:
                             initial_info = processed.info
                         p.seed = processed.seed + 1

--- a/scripts/ddetailer.py
+++ b/scripts/ddetailer.py
@@ -263,7 +263,7 @@ class DetectionDetailerScript(scripts.Script):
                         p.negative_prompt = init_neg_prompt
                         processed = processing.process_images(p)
                         p.prompt = p_txt.prompt
-                        p.negative_prompt = p_text.negative_prompt
+                        p.negative_prompt = p_txt.negative_prompt
                         p.seed = processed.seed + 1
                         p.init_images = processed.images
 
@@ -327,8 +327,8 @@ class DetectionDetailerScript(scripts.Script):
                         p.negative_prompt = init_neg_prompt
                         processed = processing.process_images(p)
                         p.prompt = p_txt.prompt
-                        p.negative_prompt = p_text.negative_prompt
-                        if initial_info is None:
+                        p.negative_prompt = p_txt.negative_prompt
+                        if initial_info is None or initial_info != processed.info:
                             initial_info = processed.info
                         p.seed = processed.seed + 1
                         p.init_images = processed.images
@@ -344,7 +344,7 @@ class DetectionDetailerScript(scripts.Script):
         if (initial_info is None):
             initial_info = "No detections found."
 
-        return Processed(p, output_images, seed, initial_info)
+        return Processed(p, output_images, seed, p_txt.prompt)
 
 def modeldataset(model_shortname):
     path = modelpath(model_shortname)


### PR DESCRIPTION
fix to use the result prompt by other Extensions(e.g. Dynamic prompt).

I found current ddetailer implementation uses original prompt.

For example, if I use dynamic prompt syntax "a girl with {hat|sunglasses|ear rings|}"
- Current implementation gets "a girl with {hat|sunglasses|ear rings|}"

I fixed this to use the result prompt after applying other extensions
- Fixed implementation gets "a girl with hat" correctly.

I think this will work for any other extensions too.

Also, I appiled this implemetation to metadata as well.
![image](https://user-images.githubusercontent.com/32811724/232382714-cb7c37fe-8f97-470a-8bb7-cf285da53c9d.png)

However webui api gets only one 'info', so you will see original prompt on webui. (Don't worry, metadata is well applied like above)
![image](https://user-images.githubusercontent.com/32811724/232382510-02c89dd7-e8a7-4766-a83f-a6515ba1a9ed.png)
